### PR TITLE
fix:新規登録のリンク先を変更

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,7 +20,7 @@
         <% end %>
       </li>
       <li class="ml-4">
-        <%= link_to new_registration_path(resource_name), class: "btn btn-outline btn-info" do %>
+        <%= link_to new_user_registration_path, class: "btn btn-outline btn-info" do %>
         <h1>新規登録</h1>
         <% end %>
       </li>


### PR DESCRIPTION
# 概要
以下の不具合を実機にて確認
- トップ画面にアクセスする時にエラー画面表示
以下の内容を修正
- 新規登録ページの遷移先パスを変更
new_registration_path(resource_name)
↓
new_user_registration_path