### PR TITLE
add:お題テーブル、モデル作成

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,7 @@
+class Topic < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :description, length: { maximum: 255 }
+  validates :published_at, presence: true
+
+  belongs_to :user
+end

--- a/db/migrate/20250704042816_create_topics.rb
+++ b/db/migrate/20250704042816_create_topics.rb
@@ -1,0 +1,12 @@
+class CreateTopics < ActiveRecord::Migration[7.2]
+  def change
+    create_table :topics do |t|
+      t.belongs_to :user
+      t.text :title,            null: false
+      t.text :description
+      t.datetime :published_at, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_02_044421) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_04_042816) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_02_044421) do
     t.datetime "updated_at", null: false
     t.index ["genre_id"], name: "index_my_genres_on_genre_id"
     t.index ["user_id"], name: "index_my_genres_on_user_id"
+  end
+
+  create_table "topics", force: :cascade do |t|
+    t.bigint "user_id"
+    t.text "title", null: false
+    t.text "description"
+    t.datetime "published_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_topics_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/fixtures/topics.yml
+++ b/test/fixtures/topics.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  text: MyString
+  description: MyString
+  text: MyString
+  published_at: MyString
+  datetime: MyString
+
+two:
+  title: MyString
+  text: MyString
+  description: MyString
+  text: MyString
+  published_at: MyString
+  datetime: MyString

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TopicTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 実装内容
- topicテーブルのモデル、マイグレーションファイルを作成
- モデルファイル
   - タイトル、説明、公開時間のバリデーション定義
   - ユーザーとのbelongs_toを定義
- マイグレーションファイル
以下のカラムを定義
   - user_id
   - title
   - description
   - published_at