### PR TITLE
add:ヒントモデル、テーブル作成。一部topicモデル修正

### DIFF
--- a/app/models/hint.rb
+++ b/app/models/hint.rb
@@ -1,0 +1,5 @@
+class Hint < ApplicationRecord
+  validates :body, presence: true, length: { maximum: 30 }
+
+  belongs_to :topic
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -3,5 +3,6 @@ class Topic < ApplicationRecord
   validates :description, length: { maximum: 255 }
   validates :published_at, presence: true
 
+  has_many :hints, dependent: :destroy
   belongs_to :user
 end

--- a/db/migrate/20250704045908_create_hints.rb
+++ b/db/migrate/20250704045908_create_hints.rb
@@ -1,0 +1,10 @@
+class CreateHints < ActiveRecord::Migration[7.2]
+  def change
+    create_table :hints do |t|
+      t.belongs_to :topic
+      t.text :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_04_042816) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_04_045908) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_04_042816) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "hints", force: :cascade do |t|
+    t.bigint "topic_id"
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["topic_id"], name: "index_hints_on_topic_id"
   end
 
   create_table "my_genres", force: :cascade do |t|

--- a/test/fixtures/hints.yml
+++ b/test/fixtures/hints.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/hint_test.rb
+++ b/test/models/hint_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class HintTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
以下のテーブルを追加しました
- ヒント
- マイグレーション
   - topic_id
   - body
- モデル
   - バリデーション
      - body
   - belongs_to :topic