### PR TITLE
fix:お題詳細のヒント表示修正

### DIFF
--- a/app/views/topics/_description.html.erb
+++ b/app/views/topics/_description.html.erb
@@ -38,7 +38,9 @@
       </div>
       <div class="flex flex-wrap gap-2">
         <% topic.hints.each do |hint| %>
+        <% if hint.body.present? %>
         <span class="bg-yellow-50 px-3 py-1 rounded-full text-xs text-yellow-700 border border-yellow-200"><%= hint.body %></span>
+        <% end %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
# 概要
## 説明
2つ以下のヒントを設定した時、黄色のラベルが表示されてしまう不具合を修正