### PR TITLE
パスワードリセット機能＆独自ドメイン取得

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,8 @@ group :development, :test do
   gem "rspec-rails", "~> 7.0.0"
 
   gem "factory_bot_rails"
+
+  gem "letter_opener_web"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -162,6 +164,17 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -411,6 +424,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kaminari
+  letter_opener_web
   pg (~> 1.1)
   pry
   pry-byebug

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -25,6 +25,18 @@ class Users::RegistrationsController < Devise::RegistrationsController
     super
   end
 
+  def edit_password
+  end
+
+  def update_password
+    if current_user.update_with_password(password_update_params)
+      bypass_sign_in(current_user, scope: :user)
+      flash[:notice] = t("devise.passwords.user.updated")
+      redirect_to mypage_path
+    else
+      render :edit_password, status: :unprocessable_entity
+    end
+  end
   # DELETE /resource
   # def destroy
   #   super
@@ -60,6 +72,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
     mypage_path
   end
 
+  def password_update_params
+    params.require(:user).permit(:current_password, :password, :password_confirmation)
+  end
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,12 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %>様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>Tatoeをご利用いただき、ありがとうございます。</p>
+<p>下記リンクより、パスワードの再設定をお願いいたします。
+</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>このメールにお心当たりのない方、ご不明な点がございましたら、以下のページにお問い合わせください。<br>
+  お問い合わせページ(未実装)</p>
+
+<p>Tatoe運営チーム</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,27 @@
-<h2>Change your password</h2>
+<div class="px-4 py-10">
+  <div class="bg-white shadow-lg rounded-2xl w-full py-8 px-4 space-y-6">
+    <div class="text-center mb-5">
+      <h2 class=" text-2xl font-bold text-gray-800">パスワード変更</h2>
+    </div>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <div class="field mb-5">
+      <%= f.label :password, "新しいパスワード", class: "block text-sm font-medium text-gray-700 mb-3" %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "input input-info text-base w-full rounded-xl border-gray-200" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <div class="field mb-5">
+      <%= f.label :password_confirmation, "確認用パスワード", class: "block text-sm font-medium text-gray-700 mb-3" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-info text-base w-full rounded-xl border-gray-200" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "パスワード変更", class: "btn w-full bg-[#A0D8EF] hover:bg-[#7CC7E8] text-white font-semibold rounded-xl" %>
+    </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,21 @@
-<h2>Forgot your password?</h2>
+<div class="px-4 py-10">
+  <div class="bg-white shadow-lg rounded-2xl w-full py-8 px-4 space-y-6">
+    <div class="text-center mb-5">
+      <h2 class=" text-2xl font-bold text-gray-800">パスワードリセット</h2>
+    </div>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <div class="field mb-5">
+      <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-3" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-info text-base w-full rounded-xl border-gray-200" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <div class="actions">
+      <%= f.submit "再設定用メール送信", class: "btn w-full bg-[#A0D8EF] hover:bg-[#7CC7E8] text-white font-semibold rounded-xl" %>
+    </div>
+    <% end %>
+
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/edit_password.html.erb
+++ b/app/views/devise/registrations/edit_password.html.erb
@@ -1,0 +1,31 @@
+<div class="px-4 py-10">
+  <div class="bg-white shadow-lg rounded-2xl w-full py-8 px-6 space-y-6">
+    <div class="text-center mb-5">
+      <h2 class="text-2xl font-bold text-gray-800">パスワード変更</h2>
+    </div>
+
+    <%= form_with model: current_user, url: users_update_password_path, method: :patch do |f| %>
+    <%= render "devise/shared/error_messages", resource: current_user %>
+
+    <div class="field mb-5">
+      <%= f.label :current_password, "現在のパスワード", class: "block text-sm font-medium text-gray-700 mb-3" %>
+      <%= f.password_field :current_password, autofocus: true, autocomplete: "current_password", class: "input input-info text-base w-full rounded-xl border-gray-200"%>
+    </div>
+
+    <div class="field mb-5">
+      <%= f.label :password, "新しいパスワード", class: "block text-sm font-medium text-gray-700 mb-3" %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "password", class: "input input-info text-base w-full rounded-xl border-gray-200"%>
+    </div>
+
+    <div class="field mb-5">
+      <%= f.label :password_confirmation, "新しいパスワードを再度入力", class: "block text-sm font-medium text-gray-700 mb-3" %>
+      <%= f.password_field :password_confirmation, autofocus: true, autocomplete: "password_confirmation", class: "input input-info text-base w-full rounded-xl border-gray-200"%>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "変更", class: "btn w-full bg-[#A0D8EF] hover:bg-[#7CC7E8] text-white font-semibold rounded-xl" %>
+    </div>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,8 +16,7 @@
     </div>
 
     <div class="flex justify-end mb-5">
-      <%= link_to "パスワードリセット後日実装", "#", class: "text-sm text-[#0369A1] hover:underline pointer-events-none" %>
-      <%# リンクを無効化するためにpointer-events-noneを付与。パスワードリセット用リンクは_links.html.erbに記述%>
+      <%= link_to "パスワードを忘れられた方はこちら",new_user_password_path, class: "text-sm text-[#0369A1] hover:underline" %>
     </div>
 
     <div class="actions">

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,4 +1,5 @@
 <% if resource.errors.any? %>
+<%# raise %>
 <div role="alert" id="error_explanation" data-turbo-cache="false" class="alert alert-error mb-2">
   <%#
     <h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,8 +24,8 @@
 <body class="min-h-screen ">
 
   <%= render 'shared/header' %>
-  <main class="bg-white">
-    <div class="w-full pb-20 max-w-2xl mx-auto bg-[#FAFAFA]">
+  <main class="bg-white h-screen">
+    <div class="w-full h-full pb-20 max-w-2xl mx-auto bg-[#FAFAFA]">
       <% if flash[:notice] %>
       <div role="alert" class="alert alert-info">
         <%= notice %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -122,14 +122,14 @@
             </div>
             <div class=" border-t border-gray-100"></div>
 
-            <%= link_to "#", class: "flex items-center justify-between p-4 hover:bg-gray-50 rounded-b-2xl pointer-events-none opacity-25" do %>
+            <%= link_to users_edit_password_path, class: "flex items-center justify-between p-4 hover:bg-gray-50 rounded-b-2xl" do %>
             <div class="flex items-center">
               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-orange-600 mr-3">
                 <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
                 <path d="M7 11V7a5 5 0 0 1 10 0v4" />
               </svg>
               <div>
-                <div class="font-medium text-gray-800">パスワードリセット(未実装)</div>
+                <div class="font-medium text-gray-800">パスワードリセット</div>
                 <div class="text-sm text-gray-500">パスワードを変更する</div>
               </div>
             </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,6 +43,10 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
+# letter_openerの配信方法
+config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,10 +96,10 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [
+    "tatoe.net",     # Allow requests from example.com
+    /.*\.tatoe\.net/ # Allow requests from subdomains like `www.example.com`
+  ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -28,8 +28,19 @@ ja:
         end_at: 終了日時
     errors:
       models:
+        user:
+          attributes:
+            email:
+              not_found: 入力されたメールアドレスは存在しません。
+            password:
+              blank: を入力してください。
+            current_password:
+              invalid: が違います。
+              blank: を入力してください。
+            password_confirmation:
+              confirmation: と%{attribute}の入力が一致しません。
         genre:
           attributes:
             name:
-              blank: "を入力してください。"
-              too_long: "は%{count}文字以内で入力してください。"
+              blank: を入力してください。
+              too_long: は%{count}文字以内で入力してください。

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -17,6 +17,10 @@ ja:
       user:
         signed_up: 新規登録が完了しました。
         updated: ユーザー情報を変更しました。
+    passwords:
+      user:
+        updated: パスワードを変更しました。
+        send_instructions: 再設定用メールを送信しました。
   topic:
     create:
       success: お題を投稿しました。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,11 @@ Rails.application.routes.draw do
     sessions: "users/sessions",
     registrations: "users/registrations"
   }
+
+  devise_scope :user do
+    get "users/edit_password", to: "users/registrations#edit_password"
+    patch "users/update_password", to: "users/registrations#update_password"
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -21,4 +26,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "top#index"
+
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
# 実装概要
- 以下の状態でのパスワードリセット機能を実装
   - 未認証時(メールでのパスワードリセット)
   - 認証済み(現在のパスワードによるリセット)
- 独自ドメイン取得(本番環境未検証)
# 現在抱えている課題
メールによるパスワードリセットを実装していたが、Tatoeから送信するメールアドレスを決めていなかったため、先に独自ドメインを取得した。
独自ドメインが無事反映されたらメールアドレスを新たに取得する