### PR TITLE
fix:パスワードリセットメールタイトル変更

### DIFF
--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -21,6 +21,9 @@ ja:
       user:
         updated: パスワードを変更しました。
         send_instructions: 再設定用メールを送信しました。
+    mailer:
+      reset_password_instructions:
+        subject: パスワード再設定のお知らせ
   topic:
     create:
       success: お題を投稿しました。


### PR DESCRIPTION
# 概要
パスワードリセットメールのタイトルを日本語化対応