### PR TITLE
fix:指定した拡張子以外の画像ファイルを登録した処理を修正

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -3,20 +3,22 @@ class MypagesController < ApplicationController
     @user = User.includes(:topics, :answers, :genres).find(current_user.id)
   end
   def update
-    user = current_user
-    if user.update(avatar: avatar_params[:avatar])
+    @user = User.includes(:topics, :answers, :genres).find(current_user.id)
+    if @user.update(avatar_params)
       redirect_to mypage_path, notice: "アバターを登録しました。"
     else
-      render :edit, status: :unprocessable_entity, alert: "アバター登録に失敗しました。登録出来るファイル拡張子を確認の上、再度お試しください。"
+      @user.reload
+      render :show, status: :unprocessable_entity
     end
   end
   def destroy
-    user = current_user
-    user.remove_avatar!
-    if user.save
+    @user = User.includes(:topics, :answers, :genres).find(current_user.id)
+    @user.remove_avatar!
+    if @user.save
       redirect_to mypage_path, notice: "アバターをリセットしました。"
     else
-      render :edit, status: :unprocessable_entity, alert: "アバターリセットに失敗しました。再度お試しください。"
+      @user.reload
+      render :show, status: :unprocessable_entity, alert: "アバターリセットに失敗しました。再度お試しください。"
     end
   end
 

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,3 +1,4 @@
+<%= render 'shared/error_messages', object: @user %>
 <div class="px-4 py-10">
   <div class="bg-white shadow-lg rounded-2xl w-full py-8 px-6 space-y-6">
     <div class="text-center mb-5">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,7 +12,7 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: 確認用パスワード
-        avatar: アイコン写真
+        avatar: アバター
         current_password: 登録しているパスワード
       topic:
         title: お題タイトル

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -41,3 +41,6 @@ ja:
       failure: 例え内容に不備があります。
     deleted:
       success: 例えを削除しました。
+  errors:
+    messages:
+        extension_allowlist_error: を登録できる拡張子はjpg jpeg pngのみとなります。


### PR DESCRIPTION
# 修正内容
指定外の拡張子を投稿した時に、エラー画面を吐いてしまう処理を修正
- mypage:updataのfalse処理について
false後の処理のrender先がeditになっていたため、showに変更
- render後、アバター情報が表示されない不具合修正
carrierwave側にて、def extension_allowlistで指定していない拡張子が渡された時、avatarをnilにした状態でオブジェクトを返すという仕様が存在しているそうです。
なので、updateを実施した後@user.reloadを実行して、DBに保存されている@userを更新してマイページにrenderする処理を記述