### PR TITLE
マイページの表示不具合の修正

### DIFF
--- a/app/views/mypages/_answer.html.erb
+++ b/app/views/mypages/_answer.html.erb
@@ -1,29 +1,40 @@
 <div class="space-y-4">
   <% answers.each do |answer| %>
-  <%= link_to topic_path(answer.topic) do %>
-  <div class="bg-white px-4 pt-4">
-    <div class="flex justify-between">
-      <div class="flex">
-        <% if answer.topic.genres.present? %>
-        <% answer.topic.genres.each do |genre|%>
-        <span class="bg-[#E0F2FE] text-[#0369A1] text-xs px-2 py-1 rounded-full mr-1"><%= genre.name %></span>
-        <% end %>
-        <% else %>
-        <p class="text-[#0369A1]">ジャンル未設定</p>
-        <% end %>
+  <div class="bg-white p-4 rounded-xl shadow-sm answer-item">
+    <%= link_to topic_path(answer.topic) do %>
+    <div class="">
+      <div class="flex justify-between">
+        <div class="flex">
+          <% if answer.topic.genres.present? %>
+          <% answer.topic.genres.each do |genre|%>
+          <span class="bg-[#E0F2FE] text-[#0369A1] text-xs px-2 py-1 rounded-full mr-1"><%= genre.name %></span>
+          <% end %>
+          <% else %>
+          <p class="text-[#0369A1]">ジャンル未設定</p>
+          <% end %>
+        </div>
+        <div class="flex items-center space-x-2">
+          <div class="relative">
+            <div class="relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full">
+              <% if answer.topic.user.avatar.present? %>
+              <%= image_tag answer.topic.user.avatar.url, alt: "プロフィール画像", class: "aspect-square h-full w-full" %>
+              <% else %>
+              <span class="flex h-full w-full items-center justify-center rounded-full bg-[#E0F2FE] text-[#0369A1] text-2xl"><%= answer.topic.user[:name][0] %></span>
+              <% end %>
+            </div>
+          </div>
+          <span class="text-sm text-gray-600"><%= answer.topic.user.name %></span>
+        </div>
       </div>
-      <div>
-        <span class="text-sm text-gray-600"><%= answer.topic.user.name %></span>
-      </div>
+      <h2 class="mt-3 text-base font-medium text-gray-800 mb-2 topic-title"><%= answer.topic.title %></h2>
     </div>
-    <h2 class="mt-3 text-base font-medium text-gray-800 mb-2 topic-title"><%= answer.topic.title %></h2>
-  </div>
-  <div class="bg-white px-4 pb-4 rounded-xl shadow-sm answer-item">
-    <div class="bg-gray-50 rounded-xl p-3 mb-3">
-      <p class="text-gray-800 font-medium mb-2">💡 <%= answer.body %></p>
-      <% if answer.reason.present? %>
-      <p class="text-sm text-gray-600"><%= simple_format(answer.reason) %></p>
-      <% end %>
+    <div class="bg-white pb-4">
+      <div class="bg-gray-50 rounded-xl p-3 mb-3">
+        <p class="text-gray-800 font-medium mb-2">💡 <%= answer.body %></p>
+        <% if answer.reason.present? %>
+        <p class="text-sm text-gray-600"><%= simple_format(answer.reason) %></p>
+        <% end %>
+      </div>
     </div>
     <% end %>
     <div class="flex justify-between">
@@ -37,5 +48,6 @@
         <% end %>
       </div>
     </div>
-    <% end %>
   </div>
+  <% end %>
+</div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,5 +1,5 @@
 <%= render 'shared/error_messages', object: @user %>
-<div class="px-4 py-10">
+<div class="px-4 pt-10 pb-15">
   <div class="bg-white shadow-lg rounded-2xl w-full py-8 px-6 space-y-6">
     <div class="text-center mb-5">
       <h2 class="text-2xl font-bold text-gray-800">マイページ</h2>
@@ -82,7 +82,7 @@
 
         <div class=" rounded-2xl border bg-card text-card-foreground shadow-sm bg-white border-0">
           <div class="p-0">
-            <div class="collapse collapse-arrow">
+            <div class="collapse collapse-arrow cursor-pointer">
               <input type="checkbox" class="flex items-center justify-between p-4 hover:bg-gray-50 rounded-t-2xl w-full cursor-pointer">
               <div class="flex items-center collapse-title">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-[#A0D8EF] mr-3">
@@ -107,7 +107,7 @@
               </div>
             </div>
             <div class="border-t border-gray-100"></div>
-            <div class="collapse collapse-arrow">
+            <div class="collapse collapse-arrow cursor-pointer">
               <input type="checkbox" class="flex items-center justify-between p-4 hover:bg-gray-50 w-full cursor-pointer">
               <div class="flex items-center collapse-title">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 mr-3">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="bg-white border-gray-100 sticky top-0">
+<header class="bg-white border-gray-100 sticky top-0 z-40">
   <div class="navbar pl-3 pr-3 items-center justify-between">
     <div class="flex items-center space-x-2">
       <%= link_to root_path, class: "flex"  do %>


### PR DESCRIPTION
# 概要
- パスワードリセットボタンが表示されない不具合を修正
mypages/answerページにdivの閉じタグが少なかったため、場所を確認・修正
- ヘッダーの重なり順を一番上に修正
ヘッダーのクラスにz-40を定義