### PR TITLE
お題シェア機能実装(OGP未設定)

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -20,7 +20,7 @@ class TopicsController < ApplicationController
   end
 
   def show
-    @topic = Topic.includes(:user, :genres, :hints, :answers).find(params[:id])
+    @topic = Topic.includes(:user, :genres, :hints, :answers).find(params[:id]).decorate
     @answers = @topic.answers.order(created_at: :desc)
     @reactions = Reaction.all
   end

--- a/app/decorators/topic_decorator.rb
+++ b/app/decorators/topic_decorator.rb
@@ -11,10 +11,10 @@ class TopicDecorator < Draper::Decorator
 
   def x_share_encode
     message = "お題を投稿しました！例えてみてください！"
-    genres = object.genres.limit(5).map { |genre| "##{genre.name}" }.join(' ')
-    url = "https://tatoe.net/topics/#{object.id.to_s}"
+    genres = object.genres.limit(5).map { |genre| "##{genre.name}" }.join(" ")
+    url = "https://tatoe.net/topics/#{object.id}"
 
     encode_text = URI.encode_www_form_component("#{message} #{genres}")
-    return "https://twitter.com/share?text=#{encode_text}&url=#{url}"
+    "https://twitter.com/share?text=#{encode_text}&url=#{url}"
   end
 end

--- a/app/decorators/topic_decorator.rb
+++ b/app/decorators/topic_decorator.rb
@@ -11,9 +11,10 @@ class TopicDecorator < Draper::Decorator
 
   def x_share_encode
     message = "お題を投稿しました！例えてみてください！"
-    genres = object.genres.map{|genre| "#" + genre}.join(' ')
-    url = "https://tatoe.net/topics/#{object.id}"
+    genres = object.genres.limit(5).map { |genre| "##{genre.name}" }.join(' ')
+    url = "https://tatoe.net/topics/#{object.id.to_s}"
 
-    return URI.encode_www_form_component('#{message} #{genres} #{url}')
+    encode_text = URI.encode_www_form_component("#{message} #{genres}")
+    return "https://twitter.com/share?text=#{encode_text}&url=#{url}"
   end
 end

--- a/app/decorators/topic_decorator.rb
+++ b/app/decorators/topic_decorator.rb
@@ -8,4 +8,12 @@ class TopicDecorator < Draper::Decorator
       hints: object.hints.map(&:body)
     }.to_json
   end
+
+  def x_share_encode
+    message = "お題を投稿しました！例えてみてください！"
+    genres = object.genres.map{|genre| "#" + genre}.join(' ')
+    url = "https://tatoe.net/topics/#{object.id}"
+
+    return URI.encode_www_form_component('#{message} #{genres} #{url}')
+  end
 end

--- a/app/views/topics/_description.html.erb
+++ b/app/views/topics/_description.html.erb
@@ -66,9 +66,9 @@
     </div>
     <% end %>
     <!-- シェア機能 -->
-    <div>
+    <div class="flex justify-end">
       <%= link_to topic.x_share_encode, target: :_blank, rel: :noopener, class: "btn bg-black text-white border-black" do %>
-      <svg aria-label="X logo" width="16" height="12" viewBox="0 0 300 271" xmlns="http://www.w3.org/2000/svg">
+      <svg aria-label=" X logo" width="16" height="12" viewBox="0 0 300 271" xmlns="http://www.w3.org/2000/svg">
         <path fill="currentColor" d="m236 0h46l-101 115 118 156h-92.6l-72.5-94.8-83 94.8h-46l107-123-113-148h94.9l65.5 86.6zm-16.1 244h25.5l-165-218h-27.4z" />
       </svg>
       シェア！

--- a/app/views/topics/_description.html.erb
+++ b/app/views/topics/_description.html.erb
@@ -54,6 +54,7 @@
       </div>
     </div>
     <% end %>
+    <!-- 編集、削除ボタン -->
     <% if current_user && current_user.own?(topic) %>
     <div class="flex justify-between mb-2 space-x-3">
       <%= button_to edit_topic_path(topic), method: :get, form_class: "w-1/2", class: "btn btn-outline btn-info w-full rounded-xl" do %>
@@ -64,5 +65,14 @@
       <% end %>
     </div>
     <% end %>
+    <!-- シェア機能 -->
+    <div>
+      <%= link_to topic.x_share_encode, target: :_blank, rel: :noopener, class: "btn bg-black text-white border-black" do %>
+      <svg aria-label="X logo" width="16" height="12" viewBox="0 0 300 271" xmlns="http://www.w3.org/2000/svg">
+        <path fill="currentColor" d="m236 0h46l-101 115 118 156h-92.6l-72.5-94.8-83 94.8h-46l107-123-113-148h94.9l65.5 86.6zm-16.1 244h25.5l-165-218h-27.4z" />
+      </svg>
+      シェア！
+      <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
# 実装内容
- お題ページにXシェアボタンを追加
- topicデコレーターにXシェアのURL作成メソッド作成(x_share_encode)
- ボタン配置調整
# エラーに対しての対応
- link_toに指定したリンク先が"html_options"として判定されてしまう不具合
link_toは以下の引数によって構成される(link_to(name = nil, options = nil, html_options = nil, &block))
link_to "ボタンに表示する文字列", "URL", "aタグに付与するオプション"

最初以下のコードにしてみたが、デコレーターを呼び出したURLがなぜかhtml_optionsとして判定され、エラーが出てしまった。
```ruby
<%= link_to "シェア！", topic.x_share_encode, target: :_blank, rel: :noopener, class: "btn bg-black text-white border-black" do %>
<% end %>
```
どうやら第２引数に文字列やパスではなくメソッドを呼び出してしまうとhtml_optionsと認識してしまうそう。
そのため、第一引数にメソッドを定義することで、URLとして読み込むことに成功した。
```ruby
<%= link_to topic.x_share_encode, target: :_blank, rel: :noopener, class: "btn bg-black text-white border-black" do %>
シェア！
<% end %>
```
