### PR TITLE
イメージファイルに拡張子を追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
         title: page_title,
         description: "Tatoeは普段接点のない趣味や文化、職業などを、ユーザー同士で“例え”を使って共感を生むアプリです。",
         type: "website",
-        image: image_url("Tatoe_OGP"),
+        image: image_url("Tatoe_OGP.png"),
         url: request.original_url,
         locale: "ja-JP"
       },

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
# 内容
renderにてデプロイした際、画像ファイルが見つからないエラーが発生した。
renderの場合、image_urlで指定した画像ファイルに拡張子が入っていないと、読み取ることが出来ず、エラーが発生してしまうそう。
.pngを追加し、再度確認をしてみる。