### PR TITLE
X用imageを追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,8 @@ module ApplicationHelper
       },
       twitter: {
         card: "summary_large_image",
-        site: "@nobu1362622"
+        site: "@nobu1362622",
+        image: image_url("Tatoe_OGP.png")
       }
     }
   end


### PR DESCRIPTION
# 内容
エラーは無事消えましたが、X投稿時のOGP画像が表示されない不具合が発生。
ツイッターmetaタグにtwitter:imageを追加。再度確認