### PR TITLE
fix:ogp_imageコントローラに未ログインでもアクセス出来るよう修正

### DIFF
--- a/app/controllers/ogp_images_controller.rb
+++ b/app/controllers/ogp_images_controller.rb
@@ -1,4 +1,5 @@
 class OgpImagesController < ApplicationController
+  skip_before_action :authenticate_user!, only: %i[show_topic]
   def show_topic
     # topic = Topic.find(params[:id])
     topic = Topic.find(params[:id])


### PR DESCRIPTION
# 実装内容
https://cards-dev.x.com/validator
上記のサイトを使ってOGPカードが読み取れるかどうか確認したところ、以下のログが発生
```
INFO:  Page fetched successfully
INFO:  18 metatags were found
INFO:  twitter:card = summary_large_image tag found
INFO:  Card loaded successfully
WARN:  this card is redirected to https://tatoe.net/users/sign_in
```
ログイン画面にリダイレクトされているため、authenticate_user!メソッドを定義