### PR TITLE
add:googleアナリティクス設定記述

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,18 @@
   <%= display_meta_tags(default_meta_tags) %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DDHY9G0HPQ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+
+    gtag('config', 'G-DDHY9G0HPQ');
+  </script>
 
   <%= yield :head %>
 


### PR DESCRIPTION
## 概要
Googleアナリティクスの設定を記述しました。
本来は本リリース直前に設定記述予定でしたが、以下の理由があり先に実装しました。
- 事前に設定をしておいて、本リリース直前に即計測出来るようにする
- 開発中からアナリティクスの挙動を確認するため