### PR TITLE
例え投稿Xシェア動的OGP実装(お題OGP一部修正)

### DIFF
--- a/app/controllers/ogp_images_controller.rb
+++ b/app/controllers/ogp_images_controller.rb
@@ -2,7 +2,13 @@ class OgpImagesController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[show_topic]
   def show_topic
     topic = Topic.find(params[:id])
-    image = OgpCreatorService.build(topic.title).tempfile.open.read
+    image = OgpCreatorService.topic_build(topic.title).tempfile.open.read
     send_data image, type: "image/png", disposition: "inline"
+  end
+
+  def show_answer
+    topic = Topic.includes(:answers).find(params[:topic_id])
+    answer = topic.answers.find { |answer| answer.id == params[:answer_id] }
+    image = OgpCreatorService.answer_build(topic.title, answer.body)
   end
 end

--- a/app/controllers/ogp_images_controller.rb
+++ b/app/controllers/ogp_images_controller.rb
@@ -2,13 +2,14 @@ class OgpImagesController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[show_topic]
   def show_topic
     topic = Topic.find(params[:id])
-    image = OgpCreatorService.topic_build(topic.title).tempfile.open.read
+    image = OgpCreatorService.topic_build(topic.title).to_blob
     send_data image, type: "image/png", disposition: "inline"
   end
 
   def show_answer
     topic = Topic.includes(:answers).find(params[:topic_id])
-    answer = topic.answers.find { |answer| answer.id == params[:answer_id] }
-    image = OgpCreatorService.answer_build(topic.title, answer.body)
+    answer = topic.answers.find(params[:id])
+    image = OgpCreatorService.answer_build(topic.title, answer.body).to_blob
+    send_data image, type: "image/png", disposition: "inline"
   end
 end

--- a/app/services/ogp_creator_service.rb
+++ b/app/services/ogp_creator_service.rb
@@ -3,22 +3,40 @@ class OgpCreatorService
 
   BASE_IMAGE_PATH = "./app/assets/images/Tatoe_OGP.png"
   FONT = "./app/assets/fonts/Noto_Sans_JP/static/NotoSansJP-Bold.ttf"
-  GRAVITY = "center"
   TEXT_POSITION = "0,0"
   TEXT_COLOR = "white"
-  FONT_SIZE = 65
   INDENTION_COUNT = 15
   ROW_LIMIT = 3
 
-  def self.build(text)
-    text = prepare_text(text)
+  def self.topic_build(topic_title)
+    topic_text = prepare_text(topic_title)
     image = MiniMagick::Image.open(BASE_IMAGE_PATH)
     image.combine_options do |config|
+      # お題タイトル
       config.fill TEXT_COLOR
       config.font FONT
-      config.gravity GRAVITY
-      config.pointsize FONT_SIZE
-      config.draw "text #{TEXT_POSITION} '#{text}'"
+      config.gravity "center"
+      config.pointsize 65
+      config.draw "text #{TEXT_POSITION} '#{topic_text}'"
+    end
+  end
+
+  def self.answer_build(topic_title, answer_body)
+    topic_text, answer_text = [topic_title, answer_body].map{ |text| prepare_text(text) }
+    image = MiniMagick::Image.open(BASE_IMAGE_PATH)
+    image.combine_options do |config|
+      # お題タイトル
+      config.fill TEXT_COLOR
+      config.font FONT
+      config.gravity "north"
+      config.pointsize 50
+      config.draw "text #{TEXT_POSITION} '#{topic_text}'"
+       # 例え内容
+      config.fill TEXT_COLOR
+      config.font FONT
+      config.gravity "center"
+      config.pointsize 65
+      config.draw "text #{TEXT_POSITION} '#{answer_text}'"
     end
   end
 

--- a/app/services/ogp_creator_service.rb
+++ b/app/services/ogp_creator_service.rb
@@ -2,47 +2,49 @@ class OgpCreatorService
   require "mini_magick"
 
   BASE_IMAGE_PATH = "./app/assets/images/Tatoe_OGP.png"
-  FONT = "./app/assets/fonts/Noto_Sans_JP/static/NotoSansJP-Bold.ttf"
-  TEXT_POSITION = "0,0"
-  TEXT_COLOR = "white"
-  INDENTION_COUNT = 15
-  ROW_LIMIT = 3
+  FONT = "./app/assets/fonts/Noto_Sans_JP/static/NotoSansJP-ExtraBold.ttf"
+  ROW_LIMIT = 2
 
   def self.topic_build(topic_title)
-    topic_text = prepare_text(topic_title)
+    topic_text = prepare_main_text(topic_title)
     image = MiniMagick::Image.open(BASE_IMAGE_PATH)
     image.combine_options do |config|
       # お題タイトル
-      config.fill TEXT_COLOR
+      config.fill "#03B4F3"
       config.font FONT
       config.gravity "center"
       config.pointsize 65
-      config.draw "text #{TEXT_POSITION} '#{topic_text}'"
+      config.draw "text 0,0 '#{topic_text}'"
     end
   end
 
   def self.answer_build(topic_title, answer_body)
-    topic_text, answer_text = [topic_title, answer_body].map{ |text| prepare_text(text) }
+    topic_text = prepare_head_text(topic_title)
+    answer_text = prepare_main_text(answer_body)
     image = MiniMagick::Image.open(BASE_IMAGE_PATH)
     image.combine_options do |config|
-      # お題タイトル
-      config.fill TEXT_COLOR
+      # 基本設定
       config.font FONT
+      # お題タイトル
+      config.fill "#65cff2"
       config.gravity "north"
       config.pointsize 50
-      config.draw "text #{TEXT_POSITION} '#{topic_text}'"
-       # 例え内容
-      config.fill TEXT_COLOR
-      config.font FONT
+      config.draw "text 0,50 '#{topic_text}'"
+      # 例え内容
+      config.fill "#03B4F3"
       config.gravity "center"
       config.pointsize 65
-      config.draw "text #{TEXT_POSITION} '#{answer_text}'"
+      config.draw "text 0,0 '#{answer_text}'"
     end
   end
 
   private
 
-  def self.prepare_text(text)
-    text.scan(/.{1,#{INDENTION_COUNT}}/)[0...ROW_LIMIT].join("\n")
+  def self.prepare_head_text(text)
+    text.scan(/.{1,#{21}}/)[0...ROW_LIMIT].join("\n")
+  end
+
+  def self.prepare_main_text(text)
+    text.scan(/.{1,#{17}}/)[0...ROW_LIMIT].join("\n")
   end
 end

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, @answer.body) %>
+<% set_meta_tags(twitter: {image: ogp_image_topic_answer_url(@topic, @answer)})  %>
 <% set_meta_tags("turbo-refresh-scroll": "preserve") %>
 <div class="px-4 py-10">
   <div class="bg-white shadow-lg rounded-2xl w-full py-8 px-4 space-y-6">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     get :ogp_image, on: :member, to: "ogp_images#show_topic"
     resources :answers, only: %i[new show create edit update destroy] do
       post :generate_ai, on: :collection
+      get :ogp_image, on: :member, to: "ogp_images#show_answer"
       resource :answer_reactions, only: %i[create destroy]
       resources :comments, only: %i[create]
     end


### PR DESCRIPTION
# 実装内容
- ogp_images_controller.rb
   - OGPイメージ生成後のblob変換に使用するメソッド変更(tempfile.open.read→to_blob)
   - 例え投稿用アクション新規作成(show_answer)
- ogp_creator_service.rb
   - 例え動的OGP生成用メソッド作成(answer_build)
   - 文字生成用メソッド追加・修正(prepare_head_tetxt, prepare_main_text)
   - 定数定義一部修正
   - topic_buildの内容一部修正
- routes.rb
   - ogp_images#show_answer追加
- answers/show.html.erb
   - OGP用metaタグ追加(set_meta_tags)