### PR TITLE
例えXシェアボタン実装・ロジックファイル変更

### DIFF
--- a/app/decorators/answer_decorator.rb
+++ b/app/decorators/answer_decorator.rb
@@ -1,0 +1,12 @@
+class AnswerDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/decorators/topic_decorator.rb
+++ b/app/decorators/topic_decorator.rb
@@ -9,16 +9,6 @@ class TopicDecorator < Draper::Decorator
     }.to_json
   end
 
-  def x_share_encode
-    message = "お題を投稿しました！例えてみてください！"
-    genres = object.genres.limit(5).map { |genre| "##{genre.name}" }.join(" ")
-    # 画像OGPのメタデータを格納したURLを設定する
-    url = "https://tatoe.net/topics/#{object.id}"
-
-    encode_text = URI.encode_www_form_component("#{message} #{genres}")
-    "https://twitter.com/share?text=#{encode_text}&url=#{url}"
-  end
-
   private
 
   # def set_meta_tags

--- a/app/services/ogp_creator_service.rb
+++ b/app/services/ogp_creator_service.rb
@@ -38,6 +38,20 @@ class OgpCreatorService
     end
   end
 
+  def self.x_share_encode(object)
+    if object.is_a?(Topic)
+      message = "お題を投稿しました！例えてみてください！"
+      url = "https://tatoe.net/topics/#{object.id}"
+      genres = object.genres.limit(5).map { |genre| "##{genre.name}" }.join(" ")
+    else
+      message = "例えを投稿しました！コメントをしてみましょう！"
+      url = "https://tatoe.net/topics/#{object.topic_id}/answers/#{object.id}"
+      genres = object.topic.genres.limit(5).map { |genre| "##{genre.name}" }.join(" ")
+    end
+    encode_text = URI.encode_www_form_component("#{message} #{genres}")
+    "https://twitter.com/share?text=#{encode_text}&url=#{url}"
+  end
+
   private
 
   def self.prepare_head_text(text)

--- a/app/views/answer_reactions/_answer_reaction.html.erb
+++ b/app/views/answer_reactions/_answer_reaction.html.erb
@@ -1,7 +1,7 @@
 <%= link_to topic_answer_answer_reactions_path(topic_id: answer.topic_id, answer_id: answer.id, reaction_id: reaction.id),
               id: "answer_reaction_answer_#{answer.id}_reaction_#{reaction.id}",
               data: { turbo_method: :post },
-              class: "btn text-gray-400" do %>
+              class: "btn text-gray-400 rounded-xl" do %>
 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="size-[1.2em]">
   <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
 </svg>

--- a/app/views/answer_reactions/_unanswer_reaction.html.erb
+++ b/app/views/answer_reactions/_unanswer_reaction.html.erb
@@ -2,7 +2,7 @@
               method: :delete,
               id: "unanswer_reaction_answer_#{answer.id}_reaction_#{reaction.id}",
               data: { turbo_method: :delete },
-              class: "btn" do %>
+              class: "btn rounded-xl" do %>
 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="size-[1.2em] stroke-red-500 fill-red-500">
   <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
 </svg>

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -39,7 +39,15 @@
       <% end %>
     </div>
     <!-- 例えリアクション -->
-    <div class="flex justify-end">
+    <div class="flex justify-end space-x-2">
+      <div>
+        <%= link_to OgpCreatorService.x_share_encode(@answer), target: :_blank, rel: :noopener, class: "btn bg-black text-white border-black rounded-xl" do %>
+        <svg aria-label=" X logo" width="16" height="12" viewBox="0 0 300 271" xmlns="http://www.w3.org/2000/svg">
+          <path fill="currentColor" d="m236 0h46l-101 115 118 156h-92.6l-72.5-94.8-83 94.8h-46l107-123-113-148h94.9l65.5 86.6zm-16.1 244h25.5l-165-218h-27.4z" />
+        </svg>
+        シェア！
+        <% end %>
+      </div>
       <% if user_signed_in? %>
       <% @reactions.each do |reaction| %>
       <% if current_user.answer_reactions.exists?(answer_id: @answer.id, reaction_id: reaction.id) %>

--- a/app/views/topics/_answer.html.erb
+++ b/app/views/topics/_answer.html.erb
@@ -1,53 +1,68 @@
-<div class="space-y-4">
-  <% answers.each do |answer| %>
-  <div class="bg-white p-4 rounded-xl shadow-sm answer-item">
-    <div class="flex justify-between items-center mb-2">
-      <div class="flex items-center space-x-2">
-        <div class="relative">
-          <div class="relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full">
-            <%= answer.user.decorate.avatar_display? %>
-          </div>
+<% answers.each do |answer| %>
+<div class="bg-white p-4 rounded-xl shadow-sm answer-item">
+  <!-- 例え投稿ユーザー -->
+  <div class="flex justify-between items-center mb-2">
+    <div class="flex items-center space-x-2">
+      <div class="relative">
+        <div class="relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full">
+          <%= answer.user.decorate.avatar_display? %>
         </div>
-        <span class="text-lg text-gray-700"><%= answer.user.name %></span>
       </div>
-      <span class="text-xs text-gray-500"><%= l answer.published_at %></span>
+      <span class="text-lg text-gray-700"><%= answer.user.name %></span>
     </div>
-    <div class="bg-gray-50 rounded-xl p-3 mb-3">
-      <p class="text-gray-800 font-medium mb-2">💡 <%= answer.body %></p>
-      <% if answer.reason.present? %>
-      <p class="text-sm text-gray-600"><%= simple_format(answer.reason) %></p>
-      <% end %>
-    </div>
-    <div class="flex justify-end">
-      <div>
-        <%= button_to topic_answer_path(@topic,answer), method: :get, class: "btn btn-outline btn-accent rounded-xl mr-2" do%>
-        <span>コメント欄</span>
-        <% end %>
-      </div>
-      <% if current_user && current_user.own?(answer) %>
-      <div class="flex">
-        <%= button_to edit_topic_answer_path(topic_id: answer.topic_id, id: answer.id), method: :get, class: "btn btn-outline btn-info rounded-xl mr-2" do %>
-        <span>編集</span>
-        <% end %>
-        <%= button_to topic_answer_path(topic_id: answer.topic_id, id: answer.id),  method: :delete, data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？"}, class: "btn btn-outline btn-error rounded-xl" do %>
-        <span>削除</span>
-        <% end %>
-      </div>
-      <% else %>
-      <div class="flex">
-        <% if user_signed_in? %>
-        <% reactions.each do |reaction| %>
-        <% if current_user.answer_reactions.exists?(answer_id: answer.id, reaction_id: reaction.id) %>
-        <%= render "answer_reactions/unanswer_reaction", answer: answer, reaction: reaction %>
-        <% else %>
-        <%= render "answer_reactions/answer_reaction", answer: answer, reaction: reaction %>
-        <% end %>
-        <% end %>
-        <% end %>
-      </div>
-      <% end %>
-      <%# ここにコメント数記述%>
-    </div>
+    <span class="text-xs text-gray-500"><%= l answer.published_at %></span>
   </div>
-  <% end %>
+  <!-- 例え内容 -->
+  <div class="bg-gray-50 rounded-xl p-3 mb-3">
+    <p class="text-gray-800 font-medium mb-2">💡 <%= answer.body %></p>
+    <% if answer.reason.present? %>
+    <p class="text-sm text-gray-600"><%= simple_format(answer.reason) %></p>
+    <% end %>
+  </div>
+  <!-- ボタン(コメント欄、Xシェア、編集、削除) -->
+  <div class="flex justify-end space-x-2">
+    <!-- コメントボタン -->
+    <div>
+      <%= button_to topic_answer_path(@topic,answer), method: :get, class: "btn btn-outline btn-accent rounded-xl" do%>
+      <span>コメント欄</span>
+      <% end %>
+    </div>
+    <!-- Xシェアボタン -->
+    <div>
+      <%= link_to OgpCreatorService.x_share_encode(answer), target: :_blank, rel: :noopener, class: "btn bg-black text-white border-black rounded-xl" do %>
+      <svg aria-label=" X logo" width="16" height="12" viewBox="0 0 300 271" xmlns="http://www.w3.org/2000/svg">
+        <path fill="currentColor" d="m236 0h46l-101 115 118 156h-92.6l-72.5-94.8-83 94.8h-46l107-123-113-148h94.9l65.5 86.6zm-16.1 244h25.5l-165-218h-27.4z" />
+      </svg>
+      シェア！
+      <% end %>
+    </div>
+    <!-- 本人の場合、編集・削除ボタン -->
+    <% if current_user && current_user.own?(answer) %>
+    <!-- 編集ボタン -->
+    <div>
+      <%= button_to edit_topic_answer_path(topic_id: answer.topic_id, id: answer.id), method: :get, class: "btn btn-outline btn-info rounded-xl" do %>
+      <span>編集</span>
+      <% end %>
+    </div>
+    <!-- 削除ボタン -->
+    <div>
+      <%= button_to topic_answer_path(topic_id: answer.topic_id, id: answer.id),  method: :delete, data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？"}, class: "btn btn-outline btn-error rounded-xl" do %>
+      <span>削除</span>
+      <% end %>
+    </div>
+    <!-- 本人以外の場合 -->
+    <% else %>
+    <!-- サインインしている場合、リアクションボタン -->
+    <% if user_signed_in? %>
+    <% reactions.each do |reaction| %>
+    <% if current_user.answer_reactions.exists?(answer_id: answer.id, reaction_id: reaction.id) %>
+    <%= render "answer_reactions/unanswer_reaction", answer: answer, reaction: reaction %>
+    <% else %>
+    <%= render "answer_reactions/answer_reaction", answer: answer, reaction: reaction %>
+    <% end %>
+    <% end %>
+    <% end %>
+    <% end %>
+  </div>
 </div>
+<% end %>

--- a/app/views/topics/_description.html.erb
+++ b/app/views/topics/_description.html.erb
@@ -67,7 +67,7 @@
     <% end %>
     <!-- シェア機能 -->
     <div class="flex justify-end">
-      <%= link_to topic.decorate.x_share_encode, target: :_blank, rel: :noopener, class: "btn bg-black text-white border-black" do %>
+      <%= link_to OgpCreatorService.x_share_encode(topic), target: :_blank, rel: :noopener, class: "btn bg-black text-white border-black" do %>
       <svg aria-label=" X logo" width="16" height="12" viewBox="0 0 300 271" xmlns="http://www.w3.org/2000/svg">
         <path fill="currentColor" d="m236 0h46l-101 115 118 156h-92.6l-72.5-94.8-83 94.8h-46l107-123-113-148h94.9l65.5 86.6zm-16.1 244h25.5l-165-218h-27.4z" />
       </svg>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -24,7 +24,9 @@
       <h3 class="text-lg font-bold text-gray-800 mb-4">みんなの例え</h3>
 
       <% if @answers.any? %>
-      <%= render "topics/answer", answers: @answers, reactions: @reactions %>
+      <div class="space-y-4">
+        <%= render "topics/answer", answers: @answers, reactions: @reactions %>
+      </div>
       <% else %>
       <div class="text-center py-12">
         <svg class="w-12 h-12 text-gray-300 mx-auto mb-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">

--- a/spec/decorators/answer_decorator_spec.rb
+++ b/spec/decorators/answer_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe AnswerDecorator do
+end


### PR DESCRIPTION
## 概要
- topic_decoratorに記述したx_share_encodeメソッドをogp_creator_service.rbに移行。お題と例えを一つのメソッドで管理
- Xシェアボタンを押した時の処理を書くためにanswer用のデコレーターを作成しましたが、サービスクラスで完結させたため空白になっています。今後デコレータを書く可能性があるため、ファイルは残している状態です。
- 例え投稿にXシェアボタンを追加
- その他細かいviewの記述を修正