### PR TITLE
fix:topicsテーブルのogp_imageカラムにUploaderをマウント処理

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -15,6 +15,7 @@ class Topic < ApplicationRecord
   has_many :pickups, dependent: :destroy
   has_many :likes, as: :likeable
   belongs_to :user
+  mount_uploader :ogp_image, AvatarUploader
 
   attr_accessor :genre_names
   accepts_nested_attributes_for :hints, allow_destroy: true


### PR DESCRIPTION
# 実装内容
本番環境適用後、お題詳細ページにアクセス時、エラーが発生
ogp_image対象のカラムにアップローダーをマウントする処理を記述